### PR TITLE
Add `-f` option to suppress warnings.

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,18 +1,3 @@
 xelatex SEU_BeamerTemplate
 xelatex SEU_BeamerTemplate
-rm *.aux
-rm *.bak
-rm *.log
-rm *.bbl
-rm *.dvi
-rm *.blg
-rm *.thm
-rm *.toc
-rm *.out
-rm *.lof
-rm *.lol
-rm *.lot
-rm *.nav
-rm *.snm
-rm *.fdb_latexmk
-rm *.synctex.gz
+rm -f *.aux *.bak *.log *.bbl *.dvi *.blg *.thm *.toc *.out *.lof *.lol *.lot *.nav *.snm *.fdb_latexmk *.synctex.gz


### PR DESCRIPTION
Add `-f` option for `rm` command, to suppress various warnings.

```sh
# Before:
rm: *.bak: No such file or directory
rm: *.bbl: No such file or directory
rm: *.dvi: No such file or directory
rm: *.blg: No such file or directory
rm: *.thm: No such file or directory
rm: *.lof: No such file or directory
rm: *.lol: No such file or directory
rm: *.lot: No such file or directory
rm: *.fdb_latexmk: No such file or directory
rm: *.synctex.gz: No such file or directory

# After:
# No warnings.
```